### PR TITLE
Fix package compatibility: datasets and huggingface-hub versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ torch==2.5.1
 torchvision==0.20.1
 torchaudio==2.5.1
 
-# Transformers and Hugging Face (latest stable)
+# Transformers and Hugging Face (Python 3.12 compatible stable versions)
 transformers==4.46.3
-datasets==3.1.0
+datasets==2.21.0
 accelerate==1.1.1
-huggingface-hub==0.26.2
+huggingface-hub==0.25.2
 tokenizers==0.20.3
 safetensors==0.4.5
 

--- a/setup_amazon_linux_2023.sh
+++ b/setup_amazon_linux_2023.sh
@@ -78,9 +78,9 @@ else
     echo ""
     echo "🤗 Transformers 및 관련 라이브러리 설치 중..."
     pip3 install transformers==4.46.3
-    pip3 install datasets==3.1.0
+    pip3 install datasets==2.21.0
     pip3 install accelerate==1.1.1
-    pip3 install huggingface-hub==0.26.2
+    pip3 install huggingface-hub==0.25.2
 
     echo ""
     echo "📊 데이터 과학 라이브러리 설치 중..."


### PR DESCRIPTION
Fixed ImportError caused by incompatibility between datasets 3.1.0 and huggingface-hub 0.26.2:
- Error: cannot import name 'LastCommitInfo' from 'huggingface_hub.hf_api'

Changes:
- datasets: 3.1.0 → 2.21.0 (stable, Python 3.12 compatible)
- huggingface-hub: 0.26.2 → 0.25.2 (stable, compatible with datasets 2.21.0)

These versions are tested and verified to work together without import errors while maintaining full Python 3.12 and Tesla T4 GPU support.